### PR TITLE
Use dokkaHtml for javadoc

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/JarTasks.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/JarTasks.kt
@@ -16,7 +16,7 @@ internal val Project.docsJar: Jar
       group = "build"
       description = "Assembles Javadoc jar file from for publishing"
       archiveClassifier.set("javadoc")
-      tasks.findByName("dokkaJavadoc")?.let { dokkaJavadoc -> from(dokkaJavadoc) }
+      tasks.findByName("dokkaHtml")?.let { dokkaHtml -> from(dokkaHtml) }
     }
 
 internal val Project.sourcesJar: Jar


### PR DESCRIPTION
We're currently publshing empty doc jars, like most libraries do for MPP Kotlin.
Some libraries use the Dokka HTML output to populate the doc jar though.

This PR updates the Arrow Gradle Config to also populate the doc jar with Dokka HTML output.