### PR TITLE
Fix maven support

### DIFF
--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 group = property("projects.group").toString()
 
 tasks {
-  withType<Test>() {
+  withType<Test> {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     useJUnitPlatform()
     testLogging {
@@ -13,7 +13,7 @@ tasks {
       setEvents(listOf("passed", "skipped", "failed", "standardOut", "standardError"))
     }
   }
-  withType<KotlinCompile>() {
+  withType<KotlinCompile> {
     kotlinOptions {
       freeCompilerArgs = freeCompilerArgs + listOf("-Xskip-runtime-version-check")
       jvmTarget = "1.8"

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -14,9 +14,10 @@ import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByName
 
 /**
- * Publish the platform JAR and POM so that consumers who depend on this module and can't read Gradle module
- * metadata can still get the platform artifact and transitive dependencies from the POM
- * (see details in https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
+ * Publish the platform JAR and POM so that consumers who depend on this module and can't read
+ * Gradle module metadata can still get the platform artifact and transitive dependencies from the
+ * POM (see details in
+ * https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
 fun Project.publishPlatformArtifactsInRootModule() {
   val lambda = { platformPublication: MavenPublication ->
@@ -54,9 +55,15 @@ fun Project.publishPlatformArtifactsInRootModule() {
           }
         }
 
-        tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }.configureEach {
-          dependsOn(tasks.findByName("generatePomFileFor${platformPublication.name.capitalize()}Publication"))
-        }
+        tasks
+          .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
+          .configureEach {
+            dependsOn(
+              tasks.findByName(
+                "generatePomFileFor${platformPublication.name.capitalize()}Publication"
+              )
+            )
+          }
       }
     }
   }

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -1,0 +1,65 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package io.arrow.gradle.config.publish.internal
+
+import groovy.util.Node
+import groovy.util.NodeList
+import org.gradle.api.Project
+import org.gradle.api.XmlProvider
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.extra
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.getByName
+
+/**
+ * Publish the platform JAR and POM so that consumers who depend on this module and can't read Gradle module
+ * metadata can still get the platform artifact and transitive dependencies from the POM
+ * (see details in https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
+ */
+fun Project.publishPlatformArtifactsInRootModule() {
+  val lambda = { platformPublication: MavenPublication ->
+    afterEvaluate {
+      var platformXml: XmlProvider? = null
+      platformPublication.pom.withXml { platformXml = this }
+
+      val publishingExtension: PublishingExtension? = extensions.findByType()
+      if (publishingExtension == null) {
+        errorMessage("`maven-publish` plugin is not being applied")
+      } else {
+        configure<PublishingExtension> {
+          publications.getByName<MavenPublication>("kotlinMultiplatform") {
+            pom.withXml {
+              val root = asNode()
+              // Remove the original content and add the content from the platform POM:
+              root.children().toList().forEach { root.remove(it as Node) }
+              platformXml!!.asNode().children().forEach { root.append(it as Node) }
+
+              // Adjust the self artifact ID, as it should match the root module's coordinates:
+              ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
+
+              // Set packaging to POM to indicate that there's no artifact:
+              root.appendNode("packaging", "pom")
+              // Remove original platform dependencies, add single dependency on the platform module
+              val dependencies = (root.get("dependencies") as NodeList)[0] as Node
+              dependencies.children().toList().forEach { dependencies.remove(it as Node) }
+
+              val singleDependency = dependencies.appendNode("dependency")
+              singleDependency.appendNode("groupId", platformPublication.groupId)
+              singleDependency.appendNode("artifactId", platformPublication.artifactId)
+              singleDependency.appendNode("version", platformPublication.version)
+              singleDependency.appendNode("scope", "compile")
+            }
+          }
+        }
+
+        tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }.configureEach {
+          dependsOn(tasks.findByName("generatePomFileFor${platformPublication.name.capitalize()}Publication"))
+        }
+      }
+    }
+  }
+
+  extra.set("publishPlatformArtifactsInRootModule", lambda)
+}

--- a/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
+++ b/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
@@ -1,6 +1,7 @@
 import io.arrow.gradle.config.publish.arrowGradleConfigVersion
 import io.arrow.gradle.config.publish.internal.configureDokka
 import io.arrow.gradle.config.publish.internal.configurePublish
+import io.arrow.gradle.config.publish.internal.publishPlatformArtifactsInRootModule
 
 plugins {
   `maven-publish`
@@ -9,7 +10,7 @@ plugins {
 }
 
 configurePublish()
-
+publishPlatformArtifactsInRootModule()
 configureDokka()
 
 dependencies {


### PR DESCRIPTION
Re-add patch for properly support Maven.
In Arrow 1.0.0 users did not have to specify `-jvm` when using Maven instead of Gradle, but this broke in `1.0.1` when we moved to Arrow Gradle Config.

This happened due to the removal of following fix: https://github.com/arrow-kt/arrow/blob/1.0.1/arrow-libs/gradle/publish-mpp-root-module-in-platform.gradle

This PR ports the fix to Kotlin Gradle, which was originally inspired by KotlinX Serialziation/Coroutines:
https://github.com/Kotlin/kotlinx.serialization/blob/master/gradle/publish-mpp-root-module-in-platform.gradle
