### PR TITLE
publish jvm artifacts in mpp maven module

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -98,7 +98,7 @@ fun Project.configurePublishing(
                   publications.getByName<MavenPublication>("jvm")
                 )
               }
-else -> {
+              else -> {
                 artifactId = "${project.name}-${name}"
               }
             }

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -98,7 +98,7 @@ fun Project.configurePublishing(
                   publications.getByName<MavenPublication>("jvm")
                 )
               }
-              "metadata", "jvm", "js" -> {
+else -> {
                 artifactId = "${project.name}-${name}"
               }
             }

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -90,10 +90,13 @@ fun Project.configurePublishing(
           all {
             when (name) {
               "kotlinMultiplatform" -> {
-                // the root mpp module ID has no suffix, but for compatibility with the consumers who
+                // the root mpp module ID has no suffix, but for compatibility with the consumers
+                // who
                 // can't read Gradle module metadata, we publish the JVM artifacts in it
                 artifactId = project.name
-                publishPlatformArtifactsInRootModule(publications.getByName<MavenPublication>("jvm"))
+                publishPlatformArtifactsInRootModule(
+                  publications.getByName<MavenPublication>("jvm")
+                )
               }
               "metadata", "jvm", "js" -> {
                 artifactId = "${project.name}-${name}"

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -11,6 +11,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
 
@@ -85,6 +86,20 @@ fun Project.configurePublishing(
 
         withType<MavenPublication> {
           artifacts.forEach(::artifact)
+
+          all {
+            when (name) {
+              "kotlinMultiplatform" -> {
+                // the root mpp module ID has no suffix, but for compatibility with the consumers who
+                // can't read Gradle module metadata, we publish the JVM artifacts in it
+                artifactId = project.name
+                publishPlatformArtifactsInRootModule(publications.getByName<MavenPublication>("jvm"))
+              }
+              "metadata", "jvm", "js" -> {
+                artifactId = "${project.name}-${name}"
+              }
+            }
+          }
 
           pom {
             name.set(pomName)

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -9,7 +9,6 @@ import org.gradle.api.XmlProvider
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.extra
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByName
 
@@ -19,57 +18,49 @@ import org.gradle.kotlin.dsl.getByName
  * POM (see details in
  * https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
-fun Project.publishPlatformArtifactsInRootModule() {
-  fun publishPlatformArtifactsInRootModule(platformPublication: MavenPublication): Unit {
-    afterEvaluate {
-      var platformXml: XmlProvider? = null
-      platformPublication.pom.withXml { platformXml = this }
+fun Project.publishPlatformArtifactsInRootModule(platformPublication: MavenPublication): Unit =
+  afterEvaluate {
+    var platformXml: XmlProvider? = null
+    platformPublication.pom.withXml { platformXml = this }
 
-      val publishingExtension: PublishingExtension? = extensions.findByType()
-      if (publishingExtension == null) {
-        errorMessage("`maven-publish` plugin is not being applied")
-      } else {
-        configure<PublishingExtension> {
-          publications.getByName<MavenPublication>("kotlinMultiplatform") {
-            pom.withXml {
-              val root = asNode()
-              // Remove the original content and add the content from the platform POM:
-              root.children().toList().forEach { root.remove(it as Node) }
-              platformXml!!.asNode().children().forEach { root.append(it as Node) }
+    val publishingExtension: PublishingExtension? = extensions.findByType()
+    if (publishingExtension == null) {
+      errorMessage("`maven-publish` plugin is not being applied")
+    } else {
+      configure<PublishingExtension> {
+        publications.getByName<MavenPublication>("kotlinMultiplatform") {
+          pom.withXml {
+            val root = asNode()
+            // Remove the original content and add the content from the platform POM:
+            root.children().toList().forEach { root.remove(it as Node) }
+            platformXml!!.asNode().children().forEach { root.append(it as Node) }
 
-              // Adjust the self artifact ID, as it should match the root module's coordinates:
-              ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
+            // Adjust the self artifact ID, as it should match the root module's coordinates:
+            ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
 
-              // Set packaging to POM to indicate that there's no artifact:
-              root.appendNode("packaging", "pom")
-              // Remove original platform dependencies, add single dependency on the platform module
-              val dependencies = (root.get("dependencies") as NodeList)[0] as Node
-              dependencies.children().toList().forEach { dependencies.remove(it as Node) }
+            // Set packaging to POM to indicate that there's no artifact:
+            root.appendNode("packaging", "pom")
+            // Remove original platform dependencies, add single dependency on the platform module
+            val dependencies = (root.get("dependencies") as NodeList)[0] as Node
+            dependencies.children().toList().forEach { dependencies.remove(it as Node) }
 
-              val singleDependency = dependencies.appendNode("dependency")
-              singleDependency.appendNode("groupId", platformPublication.groupId)
-              singleDependency.appendNode("artifactId", platformPublication.artifactId)
-              singleDependency.appendNode("version", platformPublication.version)
-              singleDependency.appendNode("scope", "compile")
-            }
-            // the root mpp module ID has no suffix, but for compatibility with the consumers who
-            // can't read Gradle module metadata, we publish the JVM artifacts in it
-            publishPlatformArtifactsInRootModule(publications.getByName<MavenPublication>("jvm"))
+            val singleDependency = dependencies.appendNode("dependency")
+            singleDependency.appendNode("groupId", platformPublication.groupId)
+            singleDependency.appendNode("artifactId", platformPublication.artifactId)
+            singleDependency.appendNode("version", platformPublication.version)
+            singleDependency.appendNode("scope", "compile")
           }
         }
-
-        tasks
-          .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
-          .configureEach {
-            dependsOn(
-              tasks.findByName(
-                "generatePomFileFor${platformPublication.name.capitalize()}Publication"
-              )
-            )
-          }
       }
+
+      tasks
+        .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
+        .configureEach {
+          dependsOn(
+            tasks.findByName(
+              "generatePomFileFor${platformPublication.name.capitalize()}Publication"
+            )
+          )
+        }
     }
   }
-
-  extra.set("publishPlatformArtifactsInRootModule", ::publishPlatformArtifactsInRootModule)
-}

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -20,53 +20,54 @@ import org.gradle.kotlin.dsl.getByName
  * https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
 fun Project.publishPlatformArtifactsInRootModule() {
-  fun publishPlatformArtifactsInRootModule(platformPublication: MavenPublication): Unit =
-      afterEvaluate {
-    var platformXml: XmlProvider? = null
-    platformPublication.pom.withXml { platformXml = this }
+  fun publishPlatformArtifactsInRootModule(platformPublication: MavenPublication): Unit {
+    afterEvaluate {
+      var platformXml: XmlProvider? = null
+      platformPublication.pom.withXml { platformXml = this }
 
-    val publishingExtension: PublishingExtension? = extensions.findByType()
-    if (publishingExtension == null) {
-      errorMessage("`maven-publish` plugin is not being applied")
-    } else {
-      configure<PublishingExtension> {
-        publications.getByName<MavenPublication>("kotlinMultiplatform") {
-          pom.withXml {
-            val root = asNode()
-            // Remove the original content and add the content from the platform POM:
-            root.children().toList().forEach { root.remove(it as Node) }
-            platformXml!!.asNode().children().forEach { root.append(it as Node) }
+      val publishingExtension: PublishingExtension? = extensions.findByType()
+      if (publishingExtension == null) {
+        errorMessage("`maven-publish` plugin is not being applied")
+      } else {
+        configure<PublishingExtension> {
+          publications.getByName<MavenPublication>("kotlinMultiplatform") {
+            pom.withXml {
+              val root = asNode()
+              // Remove the original content and add the content from the platform POM:
+              root.children().toList().forEach { root.remove(it as Node) }
+              platformXml!!.asNode().children().forEach { root.append(it as Node) }
 
-            // Adjust the self artifact ID, as it should match the root module's coordinates:
-            ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
+              // Adjust the self artifact ID, as it should match the root module's coordinates:
+              ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
 
-            // Set packaging to POM to indicate that there's no artifact:
-            root.appendNode("packaging", "pom")
-            // Remove original platform dependencies, add single dependency on the platform module
-            val dependencies = (root.get("dependencies") as NodeList)[0] as Node
-            dependencies.children().toList().forEach { dependencies.remove(it as Node) }
+              // Set packaging to POM to indicate that there's no artifact:
+              root.appendNode("packaging", "pom")
+              // Remove original platform dependencies, add single dependency on the platform module
+              val dependencies = (root.get("dependencies") as NodeList)[0] as Node
+              dependencies.children().toList().forEach { dependencies.remove(it as Node) }
 
-            val singleDependency = dependencies.appendNode("dependency")
-            singleDependency.appendNode("groupId", platformPublication.groupId)
-            singleDependency.appendNode("artifactId", platformPublication.artifactId)
-            singleDependency.appendNode("version", platformPublication.version)
-            singleDependency.appendNode("scope", "compile")
+              val singleDependency = dependencies.appendNode("dependency")
+              singleDependency.appendNode("groupId", platformPublication.groupId)
+              singleDependency.appendNode("artifactId", platformPublication.artifactId)
+              singleDependency.appendNode("version", platformPublication.version)
+              singleDependency.appendNode("scope", "compile")
+            }
+            // the root mpp module ID has no suffix, but for compatibility with the consumers who
+            // can't read Gradle module metadata, we publish the JVM artifacts in it
+            publishPlatformArtifactsInRootModule(publications.getByName<MavenPublication>("jvm"))
           }
-          // the root mpp module ID has no suffix, but for compatibility with the consumers who
-          // can't read Gradle module metadata, we publish the JVM artifacts in it
-          publishPlatformArtifactsInRootModule(publications.getByName<MavenPublication>("jvm"))
         }
-      }
 
-      tasks
-        .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
-        .configureEach {
-          dependsOn(
-            tasks.findByName(
-              "generatePomFileFor${platformPublication.name.capitalize()}Publication"
+        tasks
+          .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
+          .configureEach {
+            dependsOn(
+              tasks.findByName(
+                "generatePomFileFor${platformPublication.name.capitalize()}Publication"
+              )
             )
-          )
-        }
+          }
+      }
     }
   }
 

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -31,7 +31,6 @@ fun Project.publishPlatformArtifactsInRootModule() {
     } else {
       configure<PublishingExtension> {
         publications.getByName<MavenPublication>("kotlinMultiplatform") {
-          artifactId = project.name
           pom.withXml {
             val root = asNode()
             // Remove the original content and add the content from the platform POM:

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/PublishMppRootModuleInPlatform.kt
@@ -19,48 +19,44 @@ import org.gradle.kotlin.dsl.getByName
  * https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
 fun Project.publishPlatformArtifactsInRootModule(platformPublication: MavenPublication): Unit =
-  afterEvaluate {
-    var platformXml: XmlProvider? = null
-    platformPublication.pom.withXml { platformXml = this }
+    afterEvaluate {
+  var platformXml: XmlProvider? = null
+  platformPublication.pom.withXml { platformXml = this }
 
-    val publishingExtension: PublishingExtension? = extensions.findByType()
-    if (publishingExtension == null) {
-      errorMessage("`maven-publish` plugin is not being applied")
-    } else {
-      configure<PublishingExtension> {
-        publications.getByName<MavenPublication>("kotlinMultiplatform") {
-          pom.withXml {
-            val root = asNode()
-            // Remove the original content and add the content from the platform POM:
-            root.children().toList().forEach { root.remove(it as Node) }
-            platformXml!!.asNode().children().forEach { root.append(it as Node) }
+  val publishingExtension: PublishingExtension? = extensions.findByType()
+  if (publishingExtension == null) {
+    errorMessage("`maven-publish` plugin is not being applied")
+  } else {
+    configure<PublishingExtension> {
+      publications.getByName<MavenPublication>("kotlinMultiplatform") {
+        pom.withXml {
+          val root = asNode()
+          // Remove the original content and add the content from the platform POM:
+          root.children().toList().forEach { root.remove(it as Node) }
+          platformXml!!.asNode().children().forEach { root.append(it as Node) }
 
-            // Adjust the self artifact ID, as it should match the root module's coordinates:
-            ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
+          // Adjust the self artifact ID, as it should match the root module's coordinates:
+          ((root.get("artifactId") as NodeList)[0] as Node).setValue(artifactId)
 
-            // Set packaging to POM to indicate that there's no artifact:
-            root.appendNode("packaging", "pom")
-            // Remove original platform dependencies, add single dependency on the platform module
-            val dependencies = (root.get("dependencies") as NodeList)[0] as Node
-            dependencies.children().toList().forEach { dependencies.remove(it as Node) }
+          // Set packaging to POM to indicate that there's no artifact:
+          root.appendNode("packaging", "pom")
+          // Remove original platform dependencies, add single dependency on the platform module
+          val dependencies = (root.get("dependencies") as NodeList)[0] as Node
+          dependencies.children().toList().forEach { dependencies.remove(it as Node) }
 
-            val singleDependency = dependencies.appendNode("dependency")
-            singleDependency.appendNode("groupId", platformPublication.groupId)
-            singleDependency.appendNode("artifactId", platformPublication.artifactId)
-            singleDependency.appendNode("version", platformPublication.version)
-            singleDependency.appendNode("scope", "compile")
-          }
+          val singleDependency = dependencies.appendNode("dependency")
+          singleDependency.appendNode("groupId", platformPublication.groupId)
+          singleDependency.appendNode("artifactId", platformPublication.artifactId)
+          singleDependency.appendNode("version", platformPublication.version)
+          singleDependency.appendNode("scope", "compile")
         }
       }
+    }
 
-      tasks
-        .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
-        .configureEach {
-          dependsOn(
-            tasks.findByName(
-              "generatePomFileFor${platformPublication.name.capitalize()}Publication"
-            )
-          )
-        }
+    tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }.configureEach {
+      dependsOn(
+        tasks.findByName("generatePomFileFor${platformPublication.name.capitalize()}Publication")
+      )
     }
   }
+}

--- a/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
+++ b/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
@@ -1,7 +1,6 @@
 import io.arrow.gradle.config.publish.arrowGradleConfigVersion
 import io.arrow.gradle.config.publish.internal.configureDokka
 import io.arrow.gradle.config.publish.internal.configurePublish
-import io.arrow.gradle.config.publish.internal.publishPlatformArtifactsInRootModule
 
 plugins {
   `maven-publish`
@@ -10,7 +9,6 @@ plugins {
 }
 
 configurePublish()
-publishPlatformArtifactsInRootModule()
 configureDokka()
 
 dependencies {


### PR DESCRIPTION
I've adopted the same pattern from [kotlin.coroutines](https://github.com/Kotlin/kotlinx.coroutines/blob/3574c2feca23c3e8a1ad00b5bf92e2bf04d95060/gradle/publish.gradle#L72)
Can we test this on a library first?
Does the formatting from spotlessApply seem a bit off here?