### PR TITLE
add jvm dependency to Mpp

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -133,6 +133,9 @@ fun Project.configurePublishing(
         }
       }
     }
+    tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication"}.configureEach {
+      dependsOn(tasks["generatePomFileForJvmPublication"])
+    }
   }
 }
 

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -133,7 +133,7 @@ fun Project.configurePublishing(
         }
       }
     }
-    tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication"}.configureEach {
+    tasks.matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }.configureEach {
       dependsOn(tasks["generatePomFileForJvmPublication"])
     }
   }


### PR DESCRIPTION
try to fix 
publication and sign diamond dependency, where artifacts are produced multiple times e.g.: 
```
- Gradle detected a problem with the following location: '/Users/runner/work/arrow/arrow/arrow-libs/core/arrow-annotations/build/libs/arrow-annotations-1.0.2-alpha.35-javadoc.jar.asc'. Reason: Task ':arrow-annotations:publishJsPublicationToSonatypeRepository' uses this output of task ':arrow-annotations:signIosSimulatorArm64Publication' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```