### PR TITLE
Add sign dependency

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -27,9 +27,7 @@ internal fun Project.configurePublish() {
     }
   }
 
-  tasks.signTask?.let {
-    tasks.publishTask.orNull?.dependsOn(it)
-  }
+  tasks.signTask?.let { tasks.publishTask.orNull?.dependsOn(it) }
 
   afterEvaluate {
     when {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -27,7 +27,9 @@ internal fun Project.configurePublish() {
     }
   }
 
-  tasks.publishTask.orNull?.dependsOn(tasks.signMavenPublication)
+  tasks.signTask?.let {
+    tasks.publishTask.orNull?.dependsOn(it)
+  }
 
   afterEvaluate {
     when {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -27,6 +27,8 @@ internal fun Project.configurePublish() {
     }
   }
 
+  tasks.publishTask.orNull?.dependsOn(tasks.signMavenPublication)
+
   afterEvaluate {
     when {
       isJavaPlatform -> {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
@@ -2,7 +2,7 @@
 
 package io.arrow.gradle.config.publish.internal
 
-import com.gradle.publish.PublishTask
+import org.gradle.api.DefaultTask
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
@@ -25,8 +25,8 @@ fun SigningExtension.signPublications() {
 val TaskContainer.signMavenPublication: TaskProvider<Sign>
   get() = named<Sign>("signMavenPublication")
 
-val TaskContainer.publishTask: TaskProvider<PublishTask>
-  get() = named<PublishTask>("publish")
+val TaskContainer.publishTask: TaskProvider<DefaultTask>
+  get() = named<DefaultTask>("publish")
 
 fun SigningExtension.signInMemory() {
   if (hasSigningKeyIdGradleProperty || hasSigningKeyIdEnvironmentVariable) {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
@@ -2,8 +2,13 @@
 
 package io.arrow.gradle.config.publish.internal
 
+import com.gradle.publish.PublishTask
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.named
+import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 fun SigningExtension.signPublications() {
@@ -16,6 +21,12 @@ fun SigningExtension.signPublications() {
     sign(project.extensions.getByName<PublishingExtension>("publishing").publications)
   }
 }
+
+val TaskContainer.signMavenPublication: TaskProvider<Sign>
+  get() = named<Sign>("signMavenPublication")
+
+val TaskContainer.publishTask: TaskProvider<PublishTask>
+  get() = named<PublishTask>("publish")
 
 fun SigningExtension.signInMemory() {
   if (hasSigningKeyIdGradleProperty || hasSigningKeyIdEnvironmentVariable) {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
@@ -3,12 +3,12 @@
 package io.arrow.gradle.config.publish.internal
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.named
-import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 fun SigningExtension.signPublications() {
@@ -22,8 +22,8 @@ fun SigningExtension.signPublications() {
   }
 }
 
-val TaskContainer.signMavenPublication: TaskProvider<Sign>
-  get() = named<Sign>("signMavenPublication")
+val TaskContainer.signTask: Task?
+  get() = findByName("signPluginMavenPublication") ?: findByName("signMavenPublication")
 
 val TaskContainer.publishTask: TaskProvider<DefaultTask>
   get() = named<DefaultTask>("publish")

--- a/build-src/src/main/kotlin/SignPublications.kt
+++ b/build-src/src/main/kotlin/SignPublications.kt
@@ -1,4 +1,4 @@
-import com.gradle.publish.PublishTask
+import gradle.kotlin.dsl.accessors._9c50e51fa32f43ee0acd583f3e5c6b20.publish
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.TaskContainer
@@ -10,7 +10,7 @@ import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 fun Project.signPublications() {
-  tasks.publishTask.orNull?.dependsOn(tasks.signMavenPublication)
+  tasks.publish.orNull?.dependsOn(tasks.signMavenPublication)
   configure<SigningExtension> {
     if (isSnapshot.not()) {
       try {
@@ -25,9 +25,6 @@ fun Project.signPublications() {
 
 val TaskContainer.signMavenPublication: TaskProvider<Sign>
   get() = named<Sign>("signMavenPublication")
-
-val TaskContainer.publishTask: TaskProvider<PublishTask>
-  get() = named<PublishTask>("publish")
 
 fun SigningExtension.signInMemory() {
   if (hasSigningKeyIdGradleProperty || hasSigningKeyIdEnvironmentVariable) {

--- a/build-src/src/main/kotlin/SignPublications.kt
+++ b/build-src/src/main/kotlin/SignPublications.kt
@@ -1,10 +1,16 @@
+import com.gradle.publish.PublishTask
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByName
+import org.gradle.kotlin.dsl.named
+import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 fun Project.signPublications() {
+  tasks.publishTask.orNull?.dependsOn(tasks.signMavenPublication)
   configure<SigningExtension> {
     if (isSnapshot.not()) {
       try {
@@ -16,6 +22,12 @@ fun Project.signPublications() {
     }
   }
 }
+
+val TaskContainer.signMavenPublication: TaskProvider<Sign>
+  get() = named<Sign>("signMavenPublication")
+
+val TaskContainer.publishTask: TaskProvider<PublishTask>
+  get() = named<PublishTask>("publish")
 
 fun SigningExtension.signInMemory() {
   if (hasSigningKeyIdGradleProperty || hasSigningKeyIdEnvironmentVariable) {

--- a/build-src/src/main/kotlin/SignPublications.kt
+++ b/build-src/src/main/kotlin/SignPublications.kt
@@ -1,16 +1,18 @@
-import gradle.kotlin.dsl.accessors._9c50e51fa32f43ee0acd583f3e5c6b20.publish
+import org.gradle.api.DefaultTask
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.named
-import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 fun Project.signPublications() {
-  tasks.publish.orNull?.dependsOn(tasks.signMavenPublication)
+  tasks.signTask?.let {
+    tasks.publish.orNull?.dependsOn(it)
+  }
   configure<SigningExtension> {
     if (isSnapshot.not()) {
       try {
@@ -23,8 +25,11 @@ fun Project.signPublications() {
   }
 }
 
-val TaskContainer.signMavenPublication: TaskProvider<Sign>
-  get() = named<Sign>("signMavenPublication")
+val TaskContainer.signTask: Task?
+  get() = findByName("signPluginMavenPublication") ?: findByName("signMavenPublication")
+
+val TaskContainer.publish: TaskProvider<DefaultTask>
+  get() = named<DefaultTask>("publish")
 
 fun SigningExtension.signInMemory() {
   if (hasSigningKeyIdGradleProperty || hasSigningKeyIdEnvironmentVariable) {


### PR DESCRIPTION
to fix: 
implicit dependency of task `publish` -> `sign`
e.g.; 
```
> Task :arrow-gradle-config-nexus:signPluginMavenPublication
Execution optimizations have been disabled for task ':arrow-gradle-config-nexus:signPluginMavenPublication' to ensure correctness due to the following reasons:

  - Gradle detected a problem with the following location: '/home/runner/work/arrow-gradle-config/arrow-gradle-config/arrow-gradle-config-nexus/build/libs/arrow-gradle-config-nexus-0.7.0-alpha.1-javadoc.jar.asc'. Reason: 
  Task ':arrow-gradle-config-nexus:publishIo.arrow-kt.arrow-gradle-config-nexusPluginMarkerMavenPublicationToSonatypeRepository' uses this output of task ':arrow-gradle-config-nexus:signPluginMavenPublication' without declaring an explicit or implicit dependency. 
This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
 
  - Gradle detected a problem with the following location: '/home/runner/work/arrow-gradle-config/arrow-gradle-config/arrow-gradle-config-nexus/build/libs/arrow-gradle-config-nexus-0.7.0-alpha.1-sources.jar.asc'. Reason:
   Task ':arrow-gradle-config-nexus:publishIo.arrow-kt.arrow-gradle-config-nexusPluginMarkerMavenPublicationToSonatypeRepository' uses this output of task ':arrow-gradle-config-nexus:signPluginMavenPublication' without declaring an explicit or implicit dependency. 
This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.3.3/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
https://github.com/arrow-kt/arrow-gradle-config/runs/4838141931?check_suite_focus=true