### PR TITLE
Remove unnecessary compatibility properties

### DIFF
--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -17,8 +17,6 @@ tasks {
     kotlinOptions {
       jvmTarget = "1.8"
     }
-    sourceCompatibility = JavaVersion.VERSION_1_8.toString()
-    targetCompatibility = JavaVersion.VERSION_1_8.toString()
   }
   named("clean") { doFirst { delete("$projectDir/../../../arrow-site/docs/apidocs") } }
 }


### PR DESCRIPTION
Those properties are unnecessary because the only one which currently uses Kotlin to decide the version is `kotlinOptions.jvmTarget`

In 1.7+ they are being removed.

Context: https://kotlinlang.slack.com/archives/C19FD9681/p1652816267741679