### PR TITLE
add dokka setup to be optional

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigureDokka.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigureDokka.kt
@@ -35,11 +35,8 @@ fun Project.configureDokka(): Unit =
       }
     }
   } else {
-    tasks.withType<DokkaTask>().configureEach {
-      enabled = false
-    }
+    tasks.withType<DokkaTask>().configureEach { enabled = false }
   }
-
 
 val Project.dokkaOutputDirectory: String?
   get() =
@@ -47,6 +44,4 @@ val Project.dokkaOutputDirectory: String?
       ?: System.getenv("DOKKA_OUTPUT_DIRECTORY")
 
 val Project.dokkaEnabled: Boolean
-  get() =
-    (project.properties["dokkaEnabled"]?.toString()
-      ?: "true").toBoolean()
+  get() = (project.properties["dokkaEnabled"]?.toString() ?: "true").toBoolean()

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigureDokka.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigureDokka.kt
@@ -6,36 +6,47 @@ import org.gradle.kotlin.dsl.withType
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
-fun Project.configureDokka() {
-  afterEvaluate {
-    val baseUrl: String = checkNotNull(properties["pom.smc.url"]?.toString())
+fun Project.configureDokka(): Unit =
+  if (dokkaEnabled) {
+    afterEvaluate {
+      val baseUrl: String = checkNotNull(properties["pom.smc.url"]?.toString())
 
-    tasks.withType<DokkaTask>().configureEach {
-      outputDirectory.set(
-        file(dokkaOutputDirectory ?: "${rootProject.rootDir}/arrow-site/docs/apidocs")
-      )
-      extensions.findByType<KotlinProjectExtension>()?.sourceSets?.forEach { kotlinSourceSet ->
-        dokkaSourceSets.named(kotlinSourceSet.name) {
-          perPackageOption {
-            matchingRegex.set(".*\\.internal.*") // match all .internal packages and sub-packages
-            suppress.set(true)
-          }
-          skipDeprecated.set(true)
-          reportUndocumented.set(false)
-          kotlinSourceSet.kotlin.srcDirs.forEach { srcDir ->
-            sourceLink {
-              localDirectory.set(srcDir)
-              remoteUrl.set(uri("$baseUrl/${srcDir.relativeTo(rootProject.rootDir)}").toURL())
-              remoteLineSuffix.set("#L")
+      tasks.withType<DokkaTask>().configureEach {
+        outputDirectory.set(
+          file(dokkaOutputDirectory ?: "${rootProject.rootDir}/arrow-site/docs/apidocs")
+        )
+        extensions.findByType<KotlinProjectExtension>()?.sourceSets?.forEach { kotlinSourceSet ->
+          dokkaSourceSets.named(kotlinSourceSet.name) {
+            perPackageOption {
+              matchingRegex.set(".*\\.internal.*") // match all .internal packages and sub-packages
+              suppress.set(true)
+            }
+            skipDeprecated.set(true)
+            reportUndocumented.set(false)
+            kotlinSourceSet.kotlin.srcDirs.forEach { srcDir ->
+              sourceLink {
+                localDirectory.set(srcDir)
+                remoteUrl.set(uri("$baseUrl/${srcDir.relativeTo(rootProject.rootDir)}").toURL())
+                remoteLineSuffix.set("#L")
+              }
             }
           }
         }
       }
     }
+  } else {
+    tasks.withType<DokkaTask>().configureEach {
+      enabled = false
+    }
   }
-}
+
 
 val Project.dokkaOutputDirectory: String?
   get() =
     project.properties["dokka.outputDirectory"]?.toString()
       ?: System.getenv("DOKKA_OUTPUT_DIRECTORY")
+
+val Project.dokkaEnabled: Boolean
+  get() =
+    (project.properties["dokkaEnabled"]?.toString()
+      ?: "true").toBoolean()

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/JarTasks.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/JarTasks.kt
@@ -16,7 +16,9 @@ internal val Project.docsJar: Jar
       group = "build"
       description = "Assembles Javadoc jar file from for publishing"
       archiveClassifier.set("javadoc")
-      tasks.findByName("dokkaHtml")?.let { dokkaHtml -> from(dokkaHtml) }
+      if (dokkaEnabled) {
+        tasks.findByName("dokkaHtml")?.let { dokkaHtml -> from(dokkaHtml) }
+      }
     }
 
 internal val Project.sourcesJar: Jar

--- a/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
+++ b/arrow-gradle-config-publish/src/main/kotlin/io.arrow-kt.arrow-gradle-config-publish.gradle.kts
@@ -1,6 +1,7 @@
 import io.arrow.gradle.config.publish.arrowGradleConfigVersion
 import io.arrow.gradle.config.publish.internal.configureDokka
 import io.arrow.gradle.config.publish.internal.configurePublish
+import io.arrow.gradle.config.publish.internal.dokkaEnabled
 
 plugins {
   `maven-publish`
@@ -12,7 +13,9 @@ configurePublish()
 configureDokka()
 
 dependencies {
-  "dokkaGfmPlugin"(
-    "io.arrow-kt:arrow-gradle-config-dokka-fence-workaround:$arrowGradleConfigVersion"
-  )
+  if (dokkaEnabled) {
+    "dokkaGfmPlugin"(
+      "io.arrow-kt:arrow-gradle-config-dokka-fence-workaround:$arrowGradleConfigVersion"
+    )
+  }
 }


### PR DESCRIPTION
This PR adds a custom project variable `dokkaEnabled`, since not all (arrow) projects, have a website or even need a Dokka setup, this will allow publications without the aforementioned current restrictions. See arrow-inject, arrow-endpoints, etc..