### PR TITLE
Modify `runtimeElements` configuration to use `TargetJvmVersion` 8

### DIFF
--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -16,6 +16,9 @@ tasks {
   withType<KotlinCompile> {
     kotlinOptions {
       jvmTarget = "1.8"
+      configurations["runtimeElements"].attributes {
+        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
+      }
     }
   }
   named("clean") { doFirst { delete("$projectDir/../../../arrow-site/docs/apidocs") } }


### PR DESCRIPTION
Pre 1.7.0 the `targetCompatibility` was fixing that but after removing it in `1.7.0` JetBrains hasn't provided a new way to fix it without the workaround mentioned in YouTrack

Context: https://youtrack.jetbrains.com/issue/KT-45335/kotlinOptions-jvmTarget-conflicts-with-Gradle-variants#focus=Comments-27-4765781.0-0

