### PR TITLE
Fix `targetCompatibility` and `sourceCompatibility`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,13 +31,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Build and test with Gradle
-        uses: gradle/gradle-build-action@v2.1.6
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: build
 

--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -37,13 +37,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.1.6
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: build -x spotlessCheck "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
 
@@ -64,13 +64,13 @@ jobs:
           token: ${{ secrets.TOKEN_GITHUB_ACTION }}
 
       - name: Set up Java
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Generate Tag
-        uses: gradle/gradle-build-action@v2.1.6
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: createSemverTag "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,18 +27,18 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3.3.0
+        uses: actions/setup-java@v3.4.1
         with:
           distribution: 'zulu'
           java-version: 11
 
       - name: Build and test with Gradle
-        uses: gradle/gradle-build-action@v2.1.6
+        uses: gradle/gradle-build-action@v2.2.2
         with:
           arguments: build -x spotlessCheck --scan --stacktrace
     
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v5
         with:
           gpg_private_key: ${{ secrets.SIGNING_KEY }}
           passphrase: ${{ secrets.SIGNING_KEY_PASSPHRASE }}

--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 group = property("projects.group").toString()
 
 tasks {
-  withType<Test> {
+  withType<Test>().configureEach {
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     useJUnitPlatform()
     testLogging {
@@ -13,17 +13,18 @@ tasks {
       setEvents(listOf("passed", "skipped", "failed", "standardOut", "standardError"))
     }
   }
-  withType<KotlinCompile> {
+
+  withType<JavaCompile>().configureEach {
+    targetCompatibility = "${JavaVersion.toVersion(8)}"
+    sourceCompatibility = "${JavaVersion.toVersion(8)}"
+  }
+
+  withType<KotlinCompile>().configureEach {
     kotlinOptions {
       jvmTarget = "1.8"
-      configurations["apiElements"].attributes {
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-      }
-      configurations["runtimeElements"].attributes {
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 8)
-      }
     }
   }
+
   named("clean") { doFirst { delete("$projectDir/../../../arrow-site/docs/apidocs") } }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-android = "7.0.4"
+android = "7.2.1"
 arrow = "1.1.2"
 arrowGradleConfig = "0.10.2"
-coroutines = "1.6.1"
-dokka = "1.6.21"
-gradlePublish = "0.21.0"
+coroutines = "1.6.4"
+dokka = "1.7.10"
+gradlePublish = "1.0.0"
 javierscSemverGradlePlugin = "0.1.0-alpha.10"
-kotlin = "1.6.21"
+kotlin = "1.7.10"
 nexusPublish = "1.1.0"
-spotless = "6.6.1"
+spotless = "6.9.0"
 
 [libraries]
 android = { module = "com.android.tools.build:gradle", version.ref = "android" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Here we have the new recommended approach to set Java 8 to projects with Kotlin 1.7.0 or more, so we can remove this workaround in each project which was added individually.

At the same time, I have cherry-picked the renovate dependencies too.

@i-walker I think the latest alpha was correctly working but we were using an older one based on `.2` instead of `.3`, but I don't remember.

