### PR TITLE
Remove unused SIGNING_KEY_NAME setting

### DIFF
--- a/.github/PUBLISHING.md
+++ b/.github/PUBLISHING.md
@@ -22,10 +22,9 @@
 7. Add Nexus profileId: `oss.stagingProfileId=[stagingProfileId]`
     1. Visit this [link](https://oss.sonatype.org/#stagingProfiles), select your profile and copy
        `SOME_NUMBER` from the url `https://oss.sonatype.org/#stagingProfiles;SOME_NUMBERS`
-8. Add KeyName (optional with `useInMemoryPgpKeys`): `signing.gnupg.keyName=[keyName]`
-9. Add KeyId (optional with `useInMemoryPgpKeys` and `useCpgCmd`): `signing.gnupg.keyId=[keyId]`
-10. Add Key (replace line breaks with `\n`, optional with `useGpgCmd`): `signing.gnupg.key=[key]`
-11. Add Passphrase: `signing.gnupg.passphrase=[passphrase]`
+8. Add KeyId (optional with `useInMemoryPgpKeys` and `useCpgCmd`): `signing.gnupg.keyId=[keyId]`
+9. Add Key (replace line breaks with `\n`, optional with `useGpgCmd`): `signing.gnupg.key=[key]`
+10. Add Passphrase: `signing.gnupg.passphrase=[passphrase]`
 
 ### Using environment variables method
 
@@ -37,11 +36,10 @@
 6. Add Nexus profileId: `OSS_STAGING_PROFILE_ID`
     1. Visit this [link](https://oss.sonatype.org/#stagingProfiles), select your profile and copy
        `SOME_NUMBER` from the url `https://oss.sonatype.org/#stagingProfiles;SOME_NUMBERS`
-7. Add KeyName (optional with `useInMemoryPgpKeys`): `SIGNING_KEY_NAME=[keyName]`
-8. Add KeyId (optional with `useInMemoryPgpKeys` and `useCpgCmd`): `SIGNING_KEY_ID=[keyId]`
-9. Add Key (replace line breaks with `\n`, optional with `useGpgCmd`): `SIGNING_KEY=[key]`
+7. Add KeyId (optional with `useInMemoryPgpKeys` and `useCpgCmd`): `SIGNING_KEY_ID=[keyId]`
+8. Add Key (replace line breaks with `\n`, optional with `useGpgCmd`): `SIGNING_KEY=[key]`
     1. If it is used as secret in GitHub, it is not necessary to replace all line breaks with `\n`
-10. Add Passphrase: `SIGNING_KEY_PASSPHRASE=[passphrase]`
+9. Add Passphrase: `SIGNING_KEY_PASSPHRASE=[passphrase]`
 
 ### Minimum amount of secrets for publishing via GitHub Actions
 
@@ -59,9 +57,8 @@
 1. `OSS_USER`
 2. `OSS_TOKEN`
 3. `OSS_STAGING_PROFILE_ID`
-4. `SIGNING_KEY_NAME`
-5. `SIGNING_KEY_PASSPHRASE`
-6. `SIGNING_KEY`
+4. `SIGNING_KEY_PASSPHRASE`
+5. `SIGNING_KEY`
 
 > You can use these utilities:
 > - Kleopatra, GUI for Windows

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,6 @@ env:
   OSS_USER: '${{ secrets.OSS_USER }}'
   OSS_TOKEN: '${{ secrets.OSS_TOKEN }}'
   OSS_STAGING_PROFILE_ID: '${{ secrets.OSS_STAGING_PROFILE_ID }}'
-  SIGNING_KEY_NAME: '${{ secrets.SIGNING_KEY_NAME }}'
   SIGNING_KEY_ID: '${{ secrets.SIGNING_KEY_ID }}'
   SIGNING_KEY_PASSPHRASE: '${{ secrets.SIGNING_KEY_PASSPHRASE }}'
   SIGNING_KEY: '${{ secrets.SIGNING_KEY }}'

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ not be exposed publicly):
 - Gradle properties
 
 ```properties
-signing.gnupg.keyName=[keyName]
 signing.gnupg.keyId=[keyId]
 signing.gnupg.key=[key]
 signing.gnupg.passphrase=[passphrase]
@@ -58,7 +57,6 @@ oss.stagingProfileId=[stagingProfileId]
 - Environment variables
 
 ```text
-SIGNING_KEY_NAME=[keyName]
 SIGNING_KEY_ID=[keyId]
 SIGNING_KEY=[key]
 SIGNING_KEY_PASSPHRASE=[passphrase]

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/SigningExtensions.kt
@@ -37,15 +37,6 @@ val SigningExtension.isLocal: Boolean
       it.contains("publishToMavenLocal", ignoreCase = true)
     }
 
-val SigningExtension.signingKeyName: String?
-  get() = project.getVariable("signing.gnupg.keyName", "SIGNING_KEY_NAME")
-
-val SigningExtension.hasSigningKeyNameGradleProperty: Boolean
-  get() = project.properties["signing.gnupg.keyName"]?.toString().isNullOrBlank().not()
-
-val SigningExtension.hasSigningKeyNameEnvironmentVariable: Boolean
-  get() = System.getenv("SIGNING_KEY_NAME").isNullOrBlank().not()
-
 val SigningExtension.signingKeyId: String?
   get() = project.getVariable("signing.gnupg.keyId", "SIGNING_KEY_ID")
 

--- a/build-src/src/main/kotlin/SignPublications.kt
+++ b/build-src/src/main/kotlin/SignPublications.kt
@@ -37,15 +37,6 @@ val SigningExtension.isLocal: Boolean
       it.contains("publishToMavenLocal", ignoreCase = true)
     }
 
-val SigningExtension.signingKeyName: String?
-  get() = getSigningVariable("signing.gnupg.keyName", "SIGNING_KEY_NAME")
-
-val SigningExtension.hasSigningKeyNameGradleProperty: Boolean
-  get() = project.properties["signing.gnupg.keyName"]?.toString().isNullOrBlank().not()
-
-val SigningExtension.hasSigningKeyNameEnvironmentVariable: Boolean
-  get() = System.getenv("SIGNING_KEY_NAME").isNullOrBlank().not()
-
 val SigningExtension.signingKeyId: String?
   get() = getSigningVariable("signing.gnupg.keyId", "SIGNING_KEY_ID")
 


### PR DESCRIPTION
This pull request removes the `SIGNING_KEY_NAME` setting from the signing functionality, as we no longer use it. It also updates the documentation.