### PR TITLE
Publish depends on sign

### DIFF
--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -6,12 +6,14 @@ import com.gradle.publish.PluginBundleExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 
 internal fun Project.configurePublish() {

--- a/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
+++ b/arrow-gradle-config-publish/src/main/kotlin/internal/ConfigurePublish.kt
@@ -66,6 +66,7 @@ internal fun Project.configurePublish() {
     }
 
     configure(SigningExtension::signPublications)
+    tasks.withType<AbstractPublishToMaven> { dependsOn(tasks.withType<Sign>()) }
   }
 }
 


### PR DESCRIPTION
This workaround currently seems to be present in all downstream projects. Can we merge this into the configuration and release 0.12.0?