### PR TITLE
Update to Kotlin 1.9.20 + add Wasm

### DIFF
--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -1,6 +1,6 @@
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 group = property("projects.group").toString()
 
@@ -37,6 +37,9 @@ if (isKotlinMultiplatform) {
       browser()
       nodejs()
     }
+
+    @OptIn(ExperimentalWasmDsl::class) wasmJs()
+    @OptIn(ExperimentalWasmDsl::class) wasmWasi()
 
     // Native: https://kotlinlang.org/docs/native-target-support.html
     // -- Tier 1 --
@@ -85,7 +88,7 @@ if (isKotlinMultiplatform) {
       // -- Tier 3 --
       val mingwX64Main by getting
 
-      create("nativeMain") {
+      val nativeMain = create("nativeMain") {
         dependsOn(commonMain)
         // -- Tier 1 --
         linuxX64Main.dependsOn(this)
@@ -105,6 +108,22 @@ if (isKotlinMultiplatform) {
         iosArm64Main.dependsOn(this)
         // -- Tier 3 --
         mingwX64Main.dependsOn(this)
+      }
+
+      val jsMain by getting
+
+      val wasmJsMain by getting
+      val wasmWasiMain by getting
+
+      val wasmMain = create("wasmMain") {
+        dependsOn(wasmJsMain)
+        dependsOn(wasmWasiMain)
+      }
+
+      val nonJvmMain = create("nonJvmMain") {
+        dependsOn(nativeMain)
+        dependsOn(jsMain)
+        dependsOn(wasmMain)
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-android = "7.4.1"
-arrow = "1.2.0"
+android = "8.1.0"
+arrow = "1.2.1"
 arrowGradleConfig = "0.11.0"
-coroutines = "1.7.2"
-dokka = "1.8.20"
+coroutines = "1.7.3"
+dokka = "1.9.10"
 gradlePublish = "0.21.0"
 javierscSemverGradlePlugin = "0.5.0-rc.1"
-kotlin = "1.8.22"
+kotlin = "1.9.20"
 nexusPublish = "1.3.0"
-spotless = "6.20.0"
+spotless = "6.22.0"
 
 [libraries]
 android = { module = "com.android.tools.build:gradle", version.ref = "android" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This way we can add a new shiny WebAssembly target to Arrow

Furthermore, I've realized that we have several cases of duplicated code between JS and Native. Instead of adding yet another duplication with Wasm, I've added a `nonJvmMain` source set to gather all those.