### PR TITLE
Update versions + fix test with WASM

### DIFF
--- a/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
+++ b/arrow-gradle-config-kotlin/src/main/kotlin/io.arrow-kt.arrow-gradle-config-kotlin.gradle.kts
@@ -70,60 +70,40 @@ if (isKotlinMultiplatform) {
 
     sourceSets {
       val commonMain by getting
+      val commonTest by getting
 
-      val nonJvmMain by creating {
-        dependsOn(commonMain)
-      }
+      val nonJvmMain by creating { dependsOn(commonMain) }
+      val nonJvmTest by creating { dependsOn(commonTest) }
+
+      val nativeMain by creating { dependsOn(nonJvmMain) }
+      val nativeTest by creating { dependsOn(nonJvmTest) }
 
       // Native
       // -- Tier 1 --
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val iosX64Main by getting
+      val linuxX64Main by getting { dependsOn(nativeMain) }
+      val macosX64Main by getting { dependsOn(nativeMain) }
+      val macosArm64Main by getting { dependsOn(nativeMain) }
+      val iosSimulatorArm64Main by getting { dependsOn(nativeMain) }
+      val iosX64Main by getting { dependsOn(nativeMain) }
       // -- Tier 2 --
-      val linuxArm64Main by getting
-      val watchosSimulatorArm64Main by getting
-      val watchosX64Main by getting
-      val watchosArm32Main by getting
-      val watchosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val iosArm64Main by getting
+      val linuxArm64Main by getting { dependsOn(nativeMain) }
+      val watchosSimulatorArm64Main by getting { dependsOn(nativeMain) }
+      val watchosX64Main by getting { dependsOn(nativeMain) }
+      val watchosArm32Main by getting { dependsOn(nativeMain) }
+      val watchosArm64Main by getting { dependsOn(nativeMain) }
+      val tvosSimulatorArm64Main by getting { dependsOn(nativeMain) }
+      val tvosX64Main by getting { dependsOn(nativeMain) }
+      val tvosArm64Main by getting { dependsOn(nativeMain) }
+      val iosArm64Main by getting { dependsOn(nativeMain) }
       // -- Tier 3 --
-      val mingwX64Main by getting
+      val mingwX64Main by getting { dependsOn(nativeMain) }
 
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      nativeMain.dependsOn(nonJvmMain)
-      // -- Tier 1 --
-      linuxX64Main.dependsOn(nativeMain)
-      macosX64Main.dependsOn(nativeMain)
-      macosArm64Main.dependsOn(nativeMain)
-      iosSimulatorArm64Main.dependsOn(nativeMain)
-      iosX64Main.dependsOn(nativeMain)
-      // -- Tier 2 --
-      linuxArm64Main.dependsOn(nativeMain)
-      watchosSimulatorArm64Main.dependsOn(nativeMain)
-      watchosX64Main.dependsOn(nativeMain)
-      watchosArm32Main.dependsOn(nativeMain)
-      watchosArm64Main.dependsOn(nativeMain)
-      tvosSimulatorArm64Main.dependsOn(nativeMain)
-      tvosX64Main.dependsOn(nativeMain)
-      tvosArm64Main.dependsOn(nativeMain)
-      iosArm64Main.dependsOn(nativeMain)
-      // -- Tier 3 --
-      mingwX64Main.dependsOn(nativeMain)
-
-      val jsMain by getting
-      jsMain.dependsOn(nonJvmMain)
+      val jsMain by getting { dependsOn(nonJvmMain) }
+      val jsTest by getting { dependsOn(nonJvmTest) }
 
       if (enable_wasm) {
-        val wasmJsMain by getting
-        wasmJsMain.dependsOn(nonJvmMain)
+        val wasmJsMain by getting { dependsOn(nonJvmMain) }
+        val wasmJsTest by getting { dependsOn(nonJvmTest) }
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-android = "8.2.2"
-arrow = "1.2.1"
+android = "8.3.2"
+arrow = "1.2.4"
 arrowGradleConfig = "0.11.0"
-coroutines = "1.7.3"
-dokka = "1.9.10"
+coroutines = "1.8.0"
+dokka = "1.9.20"
 gradlePublish = "0.21.0"
-javierscSemverGradlePlugin = "0.5.0-rc.6"
-kotlin = "1.9.20"
+javierscSemverGradlePlugin = "0.5.1"
+kotlin = "1.9.23"
 nexusPublish = "1.3.0"
 spotless = "6.25.0"
 


### PR DESCRIPTION
This updates some versions, and fixes the hierarchy for all tests to depend on `nativeTest`, `nonJvmTest`, and so on.